### PR TITLE
Fix version tagging for build from source

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,9 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      # The options below are identical to the default, other than main.date which is explicitly set to commit unixtime
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitTimestamp}} -X main.builtBy=goreleaser
 archives:
   - replacements:
       darwin: Darwin

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,30 @@
-VERSION := $(shell git describe --abbrev=0 --tags)
+.PHONY: test
+
+FILE     = VERSION
+TAG     := $(shell git describe --abbrev=0 --tags 2>/dev/null)
+DATE    := $(shell git log -1 --format=%ct $(TAG) 2>/dev/null)
+VERSION := $(if $(TAG),$(TAG) $(DATE),$(cat $(FILE)))
+
+flush-version:
+	@echo "$(VERSION)" > $(FILE)
 
 build:
-	go build -ldflags="-X main.version=$(VERSION)" -o bin/fzn ./cmd/term
+	make flush-version
+	@go build \
+	-buildmode=pie \
+	-ldflags="-X 'main.version=$(TAG)' -X 'main.date=$(DATE)'" \
+	-o bin/fzn ./cmd/term
+	@echo "Build complete"
+
+release:
+	make flush-version
+	goreleaser release --rm-dist
 
 test:
 	go test ./... -count=1
 
 debug:
 	dlv debug ./cmd/term/main.go
-	#dlv debug ./cmd/term/main.go -- --root=test
 
 test-debug:
 	dlv test pkg/service/*
-	#dlv test pkg/service/* -- -test.run TestServiceMove

--- a/cmd/term/main.go
+++ b/cmd/term/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/ardanlabs/conf"
@@ -21,10 +22,14 @@ const (
 	remotesArg = "cfg"
 )
 
-var version = "development"
+var (
+	version = "development"
+	date    = "0" // the linker passes a unixtime string which needs to be converted
+)
 
 func main() {
 	var cfg struct {
+		Version           conf.Version
 		Root              string
 		Colour            string `conf:"default:light"`
 		Editor            string `conf:"default:vim"`
@@ -50,7 +55,14 @@ func main() {
 			fmt.Println(usage)
 			os.Exit(0)
 		} else if err == conf.ErrVersionWanted {
-			fmt.Printf("fuzzynote %s (%s)\n", version, time.Now().Format("2006-01-02"))
+			// Convert to ISO-8601 date, fail silently if unable
+			dateString := "1970-01-01"
+			i, err := strconv.ParseInt(date, 10, 64)
+			if err == nil {
+				unixTime := time.Unix(i, 0)
+				dateString = unixTime.Format("2006-01-02")
+			}
+			fmt.Printf("fuzzynote %s (%s)\n", version, dateString)
 			os.Exit(0)
 		}
 		log.Fatalf("main : Parsing Root Config : %v", err)


### PR DESCRIPTION
At release time, a build tag is now generated and flushed to a `VERSION`
file which is written to the project root. In the Makefile, when
attempting to generate the tag, it will initially attempt to build from
the git log, but if this fails (which it will if `make build` is being
run from the packaged release source code), it will instead look to this
file to retrieve the tag. This isn't fool-proof, but works if git is
maintained as the source of truth for tagging (which is the intention)