### PR TITLE
Simplify non-git build tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,15 @@ build:
 	-o bin/fzn ./cmd/term
 	@echo "Build complete"
 
+# The following are sequential commands, but I'm separating to reduce the chance of mistakes...
+new-tag:
+	test $(tag)
+	echo "$(tag)" > $(FILE)
+	git add $(FILE)
+	git commit -m "Release: $(tag)"
+	git tag $(tag)
 release:
-	@echo "$(VERSION)" > $(FILE)
+	git push --tags
 	goreleaser release --rm-dist
 
 test:


### PR DESCRIPTION
Use current time when generating the build tag when building from source
outside of a git-repo. The tag is still inferred from the `VERSION`
file, however.

It got confusing trying to coordinate build tags inferred from git
commits with the `VERSION` file in the repo. In short, it's impossible
to enter the commit dt into a file, and have that file within the scope
of that commit (or at least my git-fu isn't good enough to know how to
wrangle it). So I've given up for now and will settle with this
solution.